### PR TITLE
Support for Kestrel server using multiple encodings.

### DIFF
--- a/src/Anemonis.AspNetCore.RequestDecompression.UnitTests/RequestDecompressionMiddlewareTests.cs
+++ b/src/Anemonis.AspNetCore.RequestDecompression.UnitTests/RequestDecompressionMiddlewareTests.cs
@@ -121,6 +121,8 @@ namespace Anemonis.AspNetCore.RequestDecompression.UnitTests
         [DataRow("unknown deflate gzip br", "", false, StatusCodes.Status415UnsupportedMediaType)]
         [DataRow("identity unknown deflate gzip br", "identity unknown", true, StatusCodes.Status200OK)]
         [DataRow("identity unknown deflate gzip br", "", false, StatusCodes.Status415UnsupportedMediaType)]
+        [DataRow("identity \"unknown\" deflate gzip br", "identity unknown", true, StatusCodes.Status200OK)]
+        [DataRow("identity \"unknown,test\" deflate gzip br", "identity unknown,test", true, StatusCodes.Status200OK)]
         public async Task InvokeAsync(string encoding1, string encoding2, bool skipUnsupportedEncodings, int statusCode)
         {
             var options = new RequestDecompressionOptions();
@@ -203,6 +205,8 @@ namespace Anemonis.AspNetCore.RequestDecompression.UnitTests
         [DataRow("unknown,deflate,gzip,br", "", false, StatusCodes.Status415UnsupportedMediaType)]
         [DataRow("identity,unknown,deflate,gzip,br", "identity,unknown", true, StatusCodes.Status200OK)]
         [DataRow("identity,unknown,deflate,gzip,br", "", false, StatusCodes.Status415UnsupportedMediaType)]
+        [DataRow("identity,\"unknown\",deflate,gzip,br", "identity,unknown", true, StatusCodes.Status200OK)]
+        [DataRow("\"identity\",unknown,deflate,gzip,br", "identity,unknown", true, StatusCodes.Status200OK)]
         public async Task InvokeAsync_SingleStringValue(string encoding1, string encoding2, bool skipUnsupportedEncodings, int statusCode)
         {
             var options = new RequestDecompressionOptions();

--- a/src/Anemonis.AspNetCore.RequestDecompression.UnitTests/RequestDecompressionMiddlewareTests.cs
+++ b/src/Anemonis.AspNetCore.RequestDecompression.UnitTests/RequestDecompressionMiddlewareTests.cs
@@ -167,6 +167,7 @@ namespace Anemonis.AspNetCore.RequestDecompression.UnitTests
 
             if (statusCode == StatusCodes.Status200OK)
             {
+                Assert.AreEqual(encoding2Values.Count, httpContext.Request.Headers[HeaderNames.ContentEncoding].Count, $"Expected {encoding2Values} to be {httpContext.Request.Headers[HeaderNames.ContentEncoding]}");
                 Assert.AreEqual(encoding2Values, httpContext.Request.Headers[HeaderNames.ContentEncoding]);
 
                 if (encoding2 == "")
@@ -180,6 +181,88 @@ namespace Anemonis.AspNetCore.RequestDecompression.UnitTests
                         contentBytes2 = ((MemoryStream)httpContext.Request.Body).ToArray();
                     }
 
+
+                    Assert.AreEqual(content, Encoding.UTF8.GetString(contentBytes2));
+                }
+            }
+
+            Assert.AreEqual(statusCode, httpContext.Response.StatusCode);
+        }
+
+        [DataTestMethod]
+        [DataRow("", "", true, StatusCodes.Status200OK)]
+        [DataRow("identity", "", true, StatusCodes.Status200OK)]
+        [DataRow("deflate", "", true, StatusCodes.Status200OK)]
+        [DataRow("gzip", "", true, StatusCodes.Status200OK)]
+        [DataRow("br", "", true, StatusCodes.Status200OK)]
+        [DataRow("unknown", "unknown", true, StatusCodes.Status200OK)]
+        [DataRow("unknown", "", false, StatusCodes.Status415UnsupportedMediaType)]
+        [DataRow("identity,deflate,gzip,br", "", true, StatusCodes.Status200OK)]
+        [DataRow("identity,deflate,gzip,br", "", false, StatusCodes.Status200OK)]
+        [DataRow("unknown,deflate,gzip,br", "unknown", true, StatusCodes.Status200OK)]
+        [DataRow("unknown,deflate,gzip,br", "", false, StatusCodes.Status415UnsupportedMediaType)]
+        [DataRow("identity,unknown,deflate,gzip,br", "identity,unknown", true, StatusCodes.Status200OK)]
+        [DataRow("identity,unknown,deflate,gzip,br", "", false, StatusCodes.Status415UnsupportedMediaType)]
+        public async Task InvokeAsync_SingleStringValue(string encoding1, string encoding2, bool skipUnsupportedEncodings, int statusCode)
+        {
+            var options = new RequestDecompressionOptions();
+
+            options.Providers.Add<DeflateDecompressionProvider>();
+            options.Providers.Add<GzipDecompressionProvider>();
+            options.Providers.Add<BrotliDecompressionProvider>();
+            options.SkipUnsupportedEncodings = skipUnsupportedEncodings;
+
+            var loggerMock = new Mock<ILogger<RequestDecompressionMiddleware>>(MockBehavior.Loose);
+
+            loggerMock
+                .Setup(o => o.IsEnabled(It.IsAny<LogLevel>()))
+                .Returns(true);
+
+            var serviceProviderMock = new Mock<IServiceProvider>(MockBehavior.Strict);
+            var optionsMock = new Mock<IOptions<RequestDecompressionOptions>>(MockBehavior.Strict);
+
+            optionsMock
+                .Setup(o => o.Value)
+                .Returns(options);
+
+            var middleware = new RequestDecompressionMiddleware(serviceProviderMock.Object, optionsMock.Object, loggerMock.Object);
+            var content = "Hello World!";
+
+            var contentBytes1 = Encoding.UTF8.GetBytes(content);
+            var contentBytes2 = default(byte[]);
+
+            var encoding1Values = new StringValues(encoding1 == "" ? null : encoding1);
+            // Middleware adds them back as multiple entries in StringValues
+            var encoding2Values = new StringValues(encoding2.Split(',', StringSplitOptions.RemoveEmptyEntries));
+
+            foreach (var encoding in encoding1.Split(',', StringSplitOptions.RemoveEmptyEntries))
+            {
+                contentBytes1 = CompressionEncoder.Encode(contentBytes1, encoding);
+            }
+
+            var httpContext = new DefaultHttpContext();
+
+            httpContext.Request.Method = HttpMethods.Post;
+            httpContext.Request.Headers.Add(HeaderNames.ContentEncoding, encoding1Values);
+            httpContext.Request.Body = new TestRequestStream(contentBytes1);
+
+            await middleware.InvokeAsync(httpContext, c => Task.CompletedTask);
+
+            if (statusCode == StatusCodes.Status200OK)
+            {
+                Assert.AreEqual(encoding2Values.Count, httpContext.Request.Headers[HeaderNames.ContentEncoding].Count, $"Expected {encoding2Values} to be {httpContext.Request.Headers[HeaderNames.ContentEncoding]}");
+                Assert.AreEqual(encoding2Values, httpContext.Request.Headers[HeaderNames.ContentEncoding]);
+
+                if (encoding2 == "")
+                {
+                    if (httpContext.Request.Body is TestRequestStream)
+                    {
+                        contentBytes2 = ((TestRequestStream)httpContext.Request.Body).ToArray();
+                    }
+                    else
+                    {
+                        contentBytes2 = ((MemoryStream)httpContext.Request.Body).ToArray();
+                    }
 
                     Assert.AreEqual(content, Encoding.UTF8.GetString(contentBytes2));
                 }

--- a/src/Anemonis.AspNetCore.RequestDecompression/Properties/ProjectInfo.props
+++ b/src/Anemonis.AspNetCore.RequestDecompression/Properties/ProjectInfo.props
@@ -1,7 +1,7 @@
 ﻿<Project>
   <PropertyGroup>
     <AssemblyVersion>1.0.0.0</AssemblyVersion>
-    <VersionPrefix>1.7.0</VersionPrefix>
+    <VersionPrefix>1.8.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <Authors><![CDATA[Alexander Kozlenko]]></Authors>

--- a/src/Anemonis.AspNetCore.RequestDecompression/RequestDecompressionMiddleware.cs
+++ b/src/Anemonis.AspNetCore.RequestDecompression/RequestDecompressionMiddleware.cs
@@ -112,20 +112,20 @@ namespace Anemonis.AspNetCore.RequestDecompression
             // There could be a single StringValues entry with comma delimited contents
             //  Content-Encoding: gzip, br, "someEncoding"
             //  string[] { "gzip", "br", "someEncoding"}
-            var encodingNamesParsed = context.Request.Headers.GetCommaSeparatedValues(HeaderNames.ContentEncoding);
-            if (encodingNamesParsed.Length == 0)
+            var encodingNames = context.Request.Headers.GetCommaSeparatedValues(HeaderNames.ContentEncoding);
+            if (encodingNames.Length == 0)
             {
                 await next?.Invoke(context);
 
                 return;
             }
 
-            var encodingsLeft = encodingNamesParsed.Length;
+            var encodingsLeft = encodingNames.Length;
             var decodingStream = context.Request.Body;
 
-            for (var i = encodingNamesParsed.Length - 1; i >= 0; i--)
+            for (var i = encodingNames.Length - 1; i >= 0; i--)
             {
-                if (!_providers.TryGetValue(encodingNamesParsed[i], out var provider))
+                if (!_providers.TryGetValue(encodingNames[i], out var provider))
                 {
                     _logger.LogRequestDecodingSkipped();
 
@@ -160,7 +160,7 @@ namespace Anemonis.AspNetCore.RequestDecompression
                 context.Request.Body = decodedStream;
             }
 
-            if (encodingsLeft != encodingNamesParsed.Length)
+            if (encodingsLeft != encodingNames.Length)
             {
                 if (encodingsLeft == 0)
                 {
@@ -173,7 +173,7 @@ namespace Anemonis.AspNetCore.RequestDecompression
                 }
                 else if (encodingsLeft == 1)
                 {
-                    context.Request.Headers[HeaderNames.ContentEncoding] = new StringValues(encodingNamesParsed[0]);
+                    context.Request.Headers[HeaderNames.ContentEncoding] = new StringValues(encodingNames[0]);
                 }
                 else
                 {
@@ -181,7 +181,7 @@ namespace Anemonis.AspNetCore.RequestDecompression
 
                     for (var i = 0; i < encodingNamesLeft.Length; i++)
                     {
-                        encodingNamesLeft[i] = encodingNamesParsed[i];
+                        encodingNamesLeft[i] = encodingNames[i];
                     }
 
                     context.Request.Headers[HeaderNames.ContentEncoding] = new StringValues(encodingNamesLeft);


### PR DESCRIPTION
### Summary

When using Kestrel server and handling a request with multiple encodings, the middleware is failing to recognize the encodings and decode. eg. `Content-Encoding: gzip, br`

### Changes

- When ContentEncoding StringValues has a single entry, check for a comma. If present, split on commas and proceed.
- Add unit tests

### Outcome

- Kestrel Server - `Content-Encoding: gzip, br` - successfully decoded

### Additional Information

- Http1Connection loads headers here:
https://github.com/dotnet/aspnetcore/blob/5aa86873c30f1f4643c801bd303901fb66af8b09/src/Servers/Kestrel/Core/src/Internal/Http/HttpHeaders.Generated.cs#L6527-L6535

 - Since there is only a single Content-Encoding header, new StringValues(valueStr) is called where valueStr == "gzip, br"
https://github.com/dotnet/aspnetcore/blob/5aa86873c30f1f4643c801bd303901fb66af8b09/src/Servers/Kestrel/Core/src/Internal/Http/HttpHeaders.Generated.cs#L6630

 - When using TryGetValue, a single entry is retrieved
https://github.com/dotnet/aspnetcore/blob/5aa86873c30f1f4643c801bd303901fb66af8b09/src/Servers/Kestrel/Core/src/Internal/Http/HttpHeaders.Generated.cs#L1876-L1880